### PR TITLE
Fix accel term in position update

### DIFF
--- a/src/rtkpos.py
+++ b/src/rtkpos.py
@@ -701,7 +701,7 @@ def udpos(nav, sol):
     F[0:6, 3:9] += np.eye(6) * tt
     # include accel terms if filter is converged
     if posvar < nav.thresar1:
-        F[3:6, 6:9] += np.eye(3) * tt**2 / 2
+        F[0:3, 6:9] += np.eye(3) * tt**2 / 2
     else:
         trace(3, 'pos var too high for accel term: %.4f\n' % posvar)
     # x=F*x, P=F*P*F


### PR DESCRIPTION
Thank you for your great tutorial (https://www.kaggle.com/code/timeverett/getting-started-with-rtklib/notebook).

I am learning a lot from your code and original rtklib.

After some trial and error, I now think the accel term in the position update by the current kalman filte looks incorrect. I think the “tt**2/2" should be applied to the coordinate terms instead of velocity terms.

I may misunderstand something, but I would appreciate it if you reviewed this.